### PR TITLE
Added logic to delete BuildTools_Full.exe

### DIFF
--- a/dotnetapp-3.5/dotnetapp-3.5/Dockerfile.build
+++ b/dotnetapp-3.5/dotnetapp-3.5/Dockerfile.build
@@ -1,12 +1,13 @@
 FROM microsoft/dotnet-framework:3.5
 
-ENV MSBUILD_DOWNLOAD_URL https://download.microsoft.com/download/E/E/D/EEDF18A8-4AED-4CE0-BEBE-70A83094FC5A/BuildTools_Full.exe 
+ENV MSBUILD_DOWNLOAD_URL https://download.microsoft.com/download/E/E/D/EEDF18A8-4AED-4CE0-BEBE-70A83094FC5A/BuildTools_Full.exe
 
-RUN powershell -NoProfile -Command \ 
-         $ErrorActionPreference = 'Stop'; \ 
-         Invoke-WebRequest %MSBUILD_DOWNLOAD_URL% -OutFile BuildTools_Full.exe; \ 
-         & BuildTools_Full.exe /Silent /Full
-                
+RUN powershell -NoProfile -Command " \
+        $ErrorActionPreference = 'Stop'; \
+        Invoke-WebRequest %MSBUILD_DOWNLOAD_URL% -OutFile BuildTools_Full.exe; \
+        ./BuildTools_Full.exe /Silent /Full /NoRestart | Out-Null; \
+        Remove-Item -Force BuildTools_Full.exe"
+
 RUN setx /M PATH "%PATH%;%ProgramFiles(x86)%\MSBUILD\14.0\bin"
 
 WORKDIR /app

--- a/dotnetapp-4.6.2/dotnetapp-4.6.2/Dockerfile.build
+++ b/dotnetapp-4.6.2/dotnetapp-4.6.2/Dockerfile.build
@@ -1,12 +1,13 @@
 FROM microsoft/dotnet-framework:4.6.2
 
-ENV MSBUILD_DOWNLOAD_URL https://download.microsoft.com/download/E/E/D/EEDF18A8-4AED-4CE0-BEBE-70A83094FC5A/BuildTools_Full.exe 
+ENV MSBUILD_DOWNLOAD_URL https://download.microsoft.com/download/E/E/D/EEDF18A8-4AED-4CE0-BEBE-70A83094FC5A/BuildTools_Full.exe
 
-RUN powershell -NoProfile -Command \ 
-         $ErrorActionPreference = 'Stop'; \ 
-         Invoke-WebRequest %MSBUILD_DOWNLOAD_URL% -OutFile BuildTools_Full.exe; \ 
-         & BuildTools_Full.exe /Silent /Full
-       
+RUN powershell -NoProfile -Command " \
+        $ErrorActionPreference = 'Stop'; \
+        Invoke-WebRequest %MSBUILD_DOWNLOAD_URL% -OutFile BuildTools_Full.exe; \
+        ./BuildTools_Full.exe /Silent /Full /NoRestart | Out-Null; \
+        Remove-Item -Force BuildTools_Full.exe"
+
 RUN setx /M PATH "%PATH%;%ProgramFiles(x86)%\MSBUILD\14.0\bin"
 
 WORKDIR /app


### PR DESCRIPTION
You can't simply add Remove-Item to delete the BuildTools_Full.exe because it will get executed before the exe finishes.  To workaround this, logic was added to wait on the exe before it is deleted.  Also removed extraneous whitespace.

@rakeshsinghranchi, @vivmishra, @dleeapho