### PR TITLE
Fix .NET 3.5 image build issue

### DIFF
--- a/dotnetapp-3.5/dotnetapp-3.5/Dockerfile.build
+++ b/dotnetapp-3.5/dotnetapp-3.5/Dockerfile.build
@@ -6,6 +6,7 @@ RUN powershell -NoProfile -Command " \
         $ErrorActionPreference = 'Stop'; \
         Invoke-WebRequest %MSBUILD_DOWNLOAD_URL% -OutFile BuildTools_Full.exe; \
         ./BuildTools_Full.exe /Silent /Full /NoRestart | Out-Null; \
+        Start-Sleep 2; \
         Remove-Item -Force BuildTools_Full.exe"
 
 RUN setx /M PATH "%PATH%;%ProgramFiles(x86)%\MSBUILD\14.0\bin"

--- a/dotnetapp-4.6.2/dotnetapp-4.6.2/Dockerfile.build
+++ b/dotnetapp-4.6.2/dotnetapp-4.6.2/Dockerfile.build
@@ -6,6 +6,7 @@ RUN powershell -NoProfile -Command " \
         $ErrorActionPreference = 'Stop'; \
         Invoke-WebRequest %MSBUILD_DOWNLOAD_URL% -OutFile BuildTools_Full.exe; \
         ./BuildTools_Full.exe /Silent /Full /NoRestart | Out-Null; \
+        Start-Sleep 2; \
         Remove-Item -Force BuildTools_Full.exe"
 
 RUN setx /M PATH "%PATH%;%ProgramFiles(x86)%\MSBUILD\14.0\bin"


### PR DESCRIPTION
Workaround to Access denied failure at Remove-Item step. Add a sleep of 2 sec before remove-item 